### PR TITLE
fix: rename npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "rimraf build && esbuild src/index.ts --bundle --minify --format=cjs --target=es2022 --outfile=build/index.cjs && esbuild src/index.ts --bundle --minify --format=esm --target=es2022 --outfile=build/index.mjs && esbuild src/resolvers/index.ts --bundle --minify --format=cjs --target=es2022 --outfile=build/resolvers/index.cjs && esbuild src/resolvers/index.ts --bundle --minify --format=esm --target=es2022 --outfile=build/resolvers/index.mjs && tsc",
-    "prepare": "npm run build && tsc && deno task dev",
+    "test:server": "npm run build && deno task dev",
     "test": "node --test",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
For some reason NPM couldn't cope with the custom script "prepare", maybe because of the prefix "pre".